### PR TITLE
精简小程序保留上传功能

### DIFF
--- a/smartyoga-miniprogram/app.json
+++ b/smartyoga-miniprogram/app.json
@@ -2,7 +2,9 @@
   "pages": [
     "pages/index/index",
     "pages/meditation/index",
-    "pages/sequence/index"
+    "pages/sequence/index",
+    "pages/photo-detect/photo-detect",
+    "pages/result/result"
   ],
   "window": {
     "backgroundTextStyle": "light",

--- a/smartyoga-miniprogram/pages/index/index.js
+++ b/smartyoga-miniprogram/pages/index/index.js
@@ -1,66 +1,17 @@
-import { DETECT_POSE_URL } from '../../utils/yoga-api.js';
+// 页面已精简，只保留三大入口：姿势序列、冥想、上传姿势照片检测
+// 已移除首页直接拍照上传与结果展示逻辑
 
 Page({
-  data: {
-    poseId: 'mountain_pose',
-    photoResult: null
-  },
-
   handleSequencePress(event) {
-    const level = event.currentTarget.dataset.level;
-    wx.navigateTo({
-      url: `/pages/sequence/index?level=${level}`,
-    });
+    const level = event.currentTarget.dataset.level || 'beginner';
+    wx.navigateTo({ url: `/pages/sequence/index?level=${level}` });
   },
 
   handleMeditationPress() {
-    wx.navigateTo({
-      url: '/pages/meditation/index',
-    });
+    wx.navigateTo({ url: '/pages/meditation/index' });
   },
 
   handleUploadPhoto() {
-    const poseId = this.data.poseId;
-    wx.chooseImage({
-      count: 1,
-      sizeType: ['original', 'compressed'],
-      sourceType: ['album', 'camera'],
-      success: (res) => {
-        const tempFilePath = res.tempFilePaths[0];
-        wx.showLoading({ title: '上传中...', mask: true });
-        wx.uploadFile({
-          url: DETECT_POSE_URL,
-          filePath: tempFilePath,
-          name: 'file',
-          formData: { poseId },
-          success: (uploadRes) => {
-            wx.hideLoading();
-            let data = {};
-            try {
-              data = JSON.parse(uploadRes.data);
-            } catch (e) {
-              wx.showToast({ title: '解析失败', icon: 'none' });
-              return;
-            }
-
-            if (data.code === 'SUCCESS' || data.code === 'OK') {
-              this.setData({
-                photoResult: {
-                  score: data.score,
-                  skeletonUrl: data.skeletonUrl,
-                  suggestion: data.suggestion || data.feedback || ''
-                }
-              });
-            } else {
-              wx.showToast({ title: data.msg || '识别失败', icon: 'none' });
-            }
-          },
-          fail: () => {
-            wx.hideLoading();
-            wx.showToast({ title: '上传失败', icon: 'none' });
-          }
-        });
-      }
-    });
+    wx.navigateTo({ url: '/pages/photo-detect/photo-detect' });
   }
 });

--- a/smartyoga-miniprogram/pages/index/index.wxml
+++ b/smartyoga-miniprogram/pages/index/index.wxml
@@ -1,3 +1,4 @@
+<!-- 首页仅保留姿势序列、冥想和上传检测入口，已移除上传结果显示 -->
 <view class="container">
   <view class="content">
     <view class="header">
@@ -34,20 +35,13 @@
         </view>
       </view>
 
-      <!-- Photo Upload Button -->
+      <!-- 上传姿势照片检测入口 -->
       <view class="button" bindtap="handleUploadPhoto">
         <view class="buttonGradient photoGradient">
           <text class="buttonText">上传照片</text>
           <text class="buttonSubtext">姿势检测</text>
         </view>
       </view>
-    </view>
-
-    <!-- Display photo detection result -->
-    <view wx:if="{{photoResult}}" class="photoResult">
-      <image wx:if="{{photoResult.skeletonUrl}}" class="resultImage" src="{{photoResult.skeletonUrl}}" mode="widthFix" />
-      <text class="resultScore">得分: {{photoResult.score}}</text>
-      <text class="resultSuggestion">{{photoResult.suggestion}}</text>
     </view>
   </view>
 </view>

--- a/smartyoga-miniprogram/pages/index/index.wxss
+++ b/smartyoga-miniprogram/pages/index/index.wxss
@@ -1,3 +1,4 @@
+/* 删除上传结果样式，仅保留按钮布局 */
 .container {
   display: flex;
   flex: 1;
@@ -89,27 +90,4 @@
 /* Gradient for photo upload button */
 .photoGradient {
   background-image: linear-gradient(to bottom, #E0F7FF, #F0FBFF);
-}
-
-/* Photo detection result styles */
-.photoResult {
-  margin-top: 30px;
-  text-align: center;
-}
-
-.resultImage {
-  width: 90%;
-  display: block;
-  margin: 0 auto 10px auto;
-}
-
-.resultScore {
-  font-size: 20px;
-  font-weight: 600;
-  margin-bottom: 5px;
-}
-
-.resultSuggestion {
-  font-size: 16px;
-  color: #4A5568;
 }

--- a/smartyoga-miniprogram/pages/meditation/index.js
+++ b/smartyoga-miniprogram/pages/meditation/index.js
@@ -1,3 +1,4 @@
+// 冥想页保留音频播放功能
 Page({
   data: {
     isPlaying: false,

--- a/smartyoga-miniprogram/pages/meditation/index.wxml
+++ b/smartyoga-miniprogram/pages/meditation/index.wxml
@@ -1,3 +1,4 @@
+<!-- 冥想页 -->
 <view class="container">
   <view class="header">
     <view bindtap="handleBack" class="backButton">

--- a/smartyoga-miniprogram/pages/meditation/index.wxss
+++ b/smartyoga-miniprogram/pages/meditation/index.wxss
@@ -1,3 +1,4 @@
+/* 冥想页样式 */
 .container {
   display: flex;
   flex-direction: column; /* Changed to column for main layout */

--- a/smartyoga-miniprogram/pages/photo-detect/photo-detect.js
+++ b/smartyoga-miniprogram/pages/photo-detect/photo-detect.js
@@ -1,3 +1,4 @@
+// 本模块负责上传姿势照片并展示结果，其余页面已移除相关功能
 // pages/photo-detect/photo-detect.js
 import { DETECT_POSE_URL } from '../../utils/yoga-api.js';
 

--- a/smartyoga-miniprogram/pages/photo-detect/photo-detect.wxml
+++ b/smartyoga-miniprogram/pages/photo-detect/photo-detect.wxml
@@ -1,3 +1,4 @@
+<!-- 上传姿势照片检测的唯一入口页 -->
 <!-- pages/photo-detect/photo-detect.wxml -->
 <view class="container">
   <!-- 错误提示 -->

--- a/smartyoga-miniprogram/pages/photo-detect/photo-detect.wxss
+++ b/smartyoga-miniprogram/pages/photo-detect/photo-detect.wxss
@@ -1,3 +1,4 @@
+/* 上传与检测结果样式 */
 /* pages/photo-detect/photo-detect.wxss */
 .container {
   min-height: 100vh;

--- a/smartyoga-miniprogram/pages/result/result.js
+++ b/smartyoga-miniprogram/pages/result/result.js
@@ -1,3 +1,4 @@
+// 展示检测结果的简洁页面
 // pages/result/result.js
 Page({
   data: {
@@ -241,10 +242,9 @@ Page({
   // 重新检测（使用 reLaunch 避免页面栈过深）
   retryDetection() {
     wx.reLaunch({
-      url: '/pages/upload/upload'
+      url: "/pages/photo-detect/photo-detect"
     });
   },
-
   // 分享给朋友
   onShareAppMessage() {
     const score = this.data.score;

--- a/smartyoga-miniprogram/pages/result/result.wxml
+++ b/smartyoga-miniprogram/pages/result/result.wxml
@@ -1,3 +1,4 @@
+<!-- 检测结果展示页 -->
 <!-- pages/result/result.wxml -->
 <view class="container">
   <!-- 错误提示 -->

--- a/smartyoga-miniprogram/pages/result/result.wxss
+++ b/smartyoga-miniprogram/pages/result/result.wxss
@@ -1,3 +1,4 @@
+/* 结果展示样式 */
 /* pages/result/result.wxss */
 .container {
   min-height: 100vh;

--- a/smartyoga-miniprogram/pages/sequence/index.js
+++ b/smartyoga-miniprogram/pages/sequence/index.js
@@ -1,733 +1,108 @@
-import { uploadFrameForScoring, DEFAULT_POSE_IMAGE } from '../../utils/yoga-api.js';
-const cloudSequenceService = require('../../utils/cloud-sequence-service.js');
-const sequenceService = require('../../utils/sequence-service.js');
-const getText = v => (typeof v === 'object' ? (v.zh || v.en || '') : v);
+// 序列页面简化为只展示体式并播放音频，移除录制和上传逻辑
+import beginner from '../../beginner.json'
+import intermediate from '../../intermediate.json'
+import advanced from '../../advanced.json'
 
 Page({
   data: {
-    level: '',
-    currentSequence: null,
-    currentPoseIndex: 0,
+    level: 'beginner',
+    sequence: null,
+    index: 0,
     isPlaying: false,
     timeRemaining: 0,
-    loading: true,
-    error: null,
-    skeletonUrl: null,
     timerId: null,
-    recordedVideo: null,
-    isProcessingFrames: false,
-    frameAnalysisResults: [],
-    topThreeFrames: [],
-    isCancelling: false,
-    currentUploadTasks: [],
-    failedUploads: [],
-    videoMetadata: {
-      duration: 0,
-      width: 0,
-      height: 0
-    },
-    frameExtractionCanvasContext: null,
-    frameExtractorVideoContext: null,
-    extractorVideoSrc: null,
-    defaultPoseImage: DEFAULT_POSE_IMAGE
+    audioCtx: null
   },
 
-  // Initialize canvas and video contexts for frame extraction
-  initializeFrameExtractionResources: function() {
-    if (!this.data.frameExtractionCanvasContext) {
-      const ctx = wx.createCanvasContext('frameExtractorCanvas', this);
-      if (!ctx) {
-        console.error('[INIT] Failed to create canvas context "frameExtractorCanvas"');
-      }
-      this.setData({ frameExtractionCanvasContext: ctx });
-    }
-    if (!this.data.frameExtractorVideoContext) {
-      const videoCtx = wx.createVideoContext('frameExtractorVideo', this);
-      if (!videoCtx) {
-        console.error('[INIT] Failed to create video context "frameExtractorVideo"');
-      }
-      this.setData({ frameExtractorVideoContext: videoCtx });
-    }
+  onLoad(options) {
+    const level = options.level || 'beginner'
+    this.setData({ level })
+    this.loadSequence(level)
   },
 
-  // Called when the hidden video element has loaded its metadata
-  onVideoLoadMetadata: function(e) {
-    wx.hideLoading();
-
-    const { duration, width, height } = e.detail;
-    console.log('[VIDEO_META] Loaded:', { duration, width, height });
-
-    if (!duration || duration <= 0 || !width || width <= 0 || !height || height <= 0) {
-      console.error('[VIDEO_META] Invalid metadata:', { duration, width, height });
-      this.setData({ isProcessingFrames: false });
-
-      wx.showModal({
-        title: '提示',
-        content: '当前环境或视频格式不支持，请在真机上重试。',
-        showCancel: false,
-        confirmText: '知道了'
-      });
-      return;
-    }
-
-    this.setData({ 
-      videoMetadata: { duration, width, height }
-    });
-    
-    this.startFrameExtractionLoop();
-  },
-
-  // Core logic for extracting frames from the video
-  startFrameExtractionLoop: async function() {
-    console.log('[FRAME_EXTRACTION] Starting frame extraction');
-    
+  loadSequence(level) {
+    let sequence = beginner
+    if (level === 'intermediate') sequence = intermediate
+    if (level === 'advanced') sequence = advanced
     this.setData({
-      isProcessingFrames: true,
-      frameAnalysisResults: [],
-      topThreeFrames: [],
-      isCancelling: false
-    });
-
-    const { duration } = this.data.videoMetadata;
-    const videoCtx = this.data.frameExtractorVideoContext;
-    const canvasCtx = this.data.frameExtractionCanvasContext;
-
-    if (!videoCtx || !canvasCtx) {
-      console.error('[FRAME_EXTRACTION] Missing contexts');
-      this.setData({ isProcessingFrames: false });
-      wx.showToast({ title: '资源错误', icon: 'none' });
-      return;
-    }
-
-    const originalWidth = this.data.videoMetadata.width;
-    const originalHeight = this.data.videoMetadata.height;
-    let targetWidth = originalWidth;
-    let targetHeight = originalHeight;
-
-    if (originalWidth > 480) {
-      targetWidth = 480;
-      targetHeight = Math.round(originalHeight * (480 / originalWidth));
-    }
-    console.log(`[FRAME_EXTRACTION] Target dimensions: ${targetWidth}x${targetHeight}`);
-
-    const extractedFramePaths = [];
-
-    // Extract frames at 2-second intervals
-    for (let t = 0; t < duration; t += 2) {
-      if (this.data.isCancelling) {
-        console.log('[FRAME_EXTRACTION] Cancelled by user');
-        this.setData({ isProcessingFrames: false, isCancelling: false });
-        wx.hideLoading();
-        return;
-      }
-
-      videoCtx.seek(t);
-      await new Promise(resolve => setTimeout(resolve, 500));
-
-      if (this.data.isCancelling) break;
-
-      canvasCtx.drawImage('frameExtractorVideo', 0, 0, targetWidth, targetHeight);
-      await new Promise(resolve => canvasCtx.draw(false, resolve));
-
-      if (this.data.isCancelling) break;
-
-      try {
-        const frameData = await wx.canvasToTempFilePath({
-          x: 0, y: 0,
-          width: targetWidth, height: targetHeight,
-          destWidth: targetWidth, destHeight: targetHeight,
-          canvasId: 'frameExtractorCanvas',
-          fileType: 'jpg', 
-          quality: 0.7
-        }, this);
-        extractedFramePaths.push(frameData.tempFilePath);
-        console.log(`[FRAME_EXTRACTION] Frame at ${t}s saved:`, frameData.tempFilePath);
-      } catch (err) {
-        console.error(`[FRAME_EXTRACTION] Failed at ${t}s:`, err);
-      }
-    }
-
-    if (this.data.isCancelling) {
-      console.log('[FRAME_EXTRACTION] Final cancellation check');
-      this.setData({ isProcessingFrames: false, isCancelling: false });
-      wx.hideLoading();
-      return;
-    }
-
-    console.log('[FRAME_EXTRACTION] Completed. Total frames:', extractedFramePaths.length);
-
-    if (extractedFramePaths.length > 0) {
-      this.analyzeFramesBatch(extractedFramePaths);
-    } else {
-      this.setData({ isProcessingFrames: false });
-      wx.showToast({ title: '未能成功提取任何帧', icon: 'none' });
-    }
+      sequence,
+      index: 0,
+      isPlaying: false,
+      timeRemaining: sequence.poses[0].duration
+    })
+    wx.setNavigationBarTitle({
+      title: `${sequence.name.zh} - 1/${sequence.poses.length}`
+    })
   },
 
-  // Handles user-initiated cancellation
-  handleCancelUpload: function() {
-    console.log('[CANCEL] User initiated cancellation');
-    this.setData({ isCancelling: true });
-
-    // Abort all ongoing upload tasks
-    const tasks = this.data.currentUploadTasks;
-    if (tasks && tasks.length > 0) {
-      console.log(`[CANCEL] Aborting ${tasks.length} upload tasks`);
-      tasks.forEach(task => {
-        if (task && typeof task.abort === 'function') {
-          task.abort();
-        }
-      });
-    }
-
-    this.setData({
-      isProcessingFrames: false,
-      currentUploadTasks: [],
-      frameAnalysisResults: [],
-      topThreeFrames: []
-    });
-    
-    wx.hideLoading();
-    wx.showToast({ title: '已取消处理', icon: 'none' });
-  },
-
-  // Analyzes a batch of extracted frames
-  analyzeFramesBatch: async function(framePathsArray, _poseId = null) {
-    if (this.data.isCancelling) {
-      console.log('[ANALYZE_BATCH] Skipped due to cancellation');
-      this.setData({ isProcessingFrames: false, isCancelling: false });
-      wx.hideLoading();
-      return;
-    }
-
-    if (!framePathsArray || framePathsArray.length === 0) {
-      if (!_poseId) {
-        wx.showToast({ title: '没有提取到帧进行分析', icon: 'none' });
-      }
-      this.setData({ isProcessingFrames: false });
-      return;
-    }
-
-    this.setData({ isProcessingFrames: true, currentUploadTasks: [] });
-    wx.showLoading({ title: '分析中 (0%)...', mask: true });
-
-    const poseId = _poseId || (
-      this.data.currentSequence && 
-      this.data.currentSequence.poses[this.data.currentPoseIndex] && 
-      this.data.currentSequence.poses[this.data.currentPoseIndex].id
-    );
-
-    if (!poseId) {
-      console.error('[ANALYZE_BATCH] No pose ID found');
-      this.setData({ isProcessingFrames: false, isCancelling: false, currentUploadTasks: [] });
-      wx.hideLoading();
-      wx.showToast({ title: '无法确定体式ID', icon: 'none' });
-      return;
-    }
-
-    console.log('[ANALYZE_BATCH] Starting analysis for poseId:', poseId);
-
-    const BATCH_SIZE = 3;
-    const totalFrames = framePathsArray.length;
-    let processedCount = 0;
-    let successfulUploads = 0;
-
-    if (!_poseId) {
-      this.setData({ frameAnalysisResults: [] });
-    }
-
-    for (let i = 0; i < totalFrames; i += BATCH_SIZE) {
-      if (this.data.isCancelling) {
-        console.log('[ANALYZE_BATCH] Cancelled in main loop');
-        break;
-      }
-
-      const currentBatchPaths = framePathsArray.slice(i, i + BATCH_SIZE);
-      const uploadPromises = [];
-      const batchTasks = [];
-
-      for (const framePath of currentBatchPaths) {
-        if (this.data.isCancelling) break;
-
-        processedCount++;
-        wx.showLoading({ 
-          title: `分析第 ${processedCount}/${totalFrames} 帧...`, 
-          mask: true 
-        });
-        
-        const { promise, task } = uploadFrameForScoring(framePath, poseId);
-        
-        // Process the promise to adapt the result structure
-        const adaptedPromise = promise
-          .then(result => {
-            console.log('[UPLOAD_FRAME] Success:', result);
-            return {
-              score: result.score || 0,
-              feedback: result.feedback || "评分完成",
-              skeletonUrl: result.skeletonUrl,
-              originalFramePath: framePath
-            };
-          })
-          .catch(err => {
-            console.error('[UPLOAD_FRAME] Failed:', err);
-            const wasAborted = err.wasAborted || false;
-            const errorMessage = err.message || 'Upload failed';
-            
-            return Promise.reject({
-              error: errorMessage,
-              originalFramePath: framePath,
-              details: err,
-              wasAborted: wasAborted
-            });
-          });
-          
-        uploadPromises.push(adaptedPromise);
-        if (task) {
-          batchTasks.push(task);
-        }
-      }
-      
-      // Add tasks to global list
-      if (batchTasks.length > 0) {
-        const currentTasks = this.data.currentUploadTasks;
-        this.setData({ 
-          currentUploadTasks: [...currentTasks, ...batchTasks] 
-        });
-      }
-
-      if (this.data.isCancelling) break;
-
-      const batchResults = await Promise.allSettled(uploadPromises);
-      
-      // Remove completed tasks from global list
-      if (batchTasks.length > 0) {
-        const updatedTasks = this.data.currentUploadTasks.filter(t => !batchTasks.includes(t));
-        this.setData({ currentUploadTasks: updatedTasks });
-      }
-
-      if (this.data.isCancelling) break;
-      
-      const currentResults = [...this.data.frameAnalysisResults];
-      batchResults.forEach(result => {
-        if (result.status === 'fulfilled') {
-          currentResults.push(result.value);
-          successfulUploads++;
-        } else {
-          currentResults.push(result.reason);
-        }
-      });
-      this.setData({ frameAnalysisResults: currentResults });
-    }
-
-    wx.hideLoading();
-    
-    if (this.data.isCancelling) {
-      console.log('[ANALYZE_BATCH] Process was cancelled');
-      this.setData({ isProcessingFrames: false, isCancelling: false, currentUploadTasks: [] });
-      return;
-    }
-
-    this.setData({ currentUploadTasks: [] });
-
-    // Store failed uploads info
-    const sessionFailedUploads = this.data.frameAnalysisResults
-      .filter(r => r.error && !r.wasAborted)
-      .map(r => ({ 
-        framePath: r.originalFramePath, 
-        poseId: poseId, 
-        error: r.error 
-      }));
-    this.setData({ failedUploads: sessionFailedUploads });
-
-    if (sessionFailedUploads.length > 0) {
-      wx.showToast({ 
-        title: `${sessionFailedUploads.length} 帧上传失败`, 
-        icon: 'none', 
-        duration: 3000 
-      });
-    }
-
-    console.log('[ANALYZE_BATCH] Complete. Success:', successfulUploads, 'Failed:', sessionFailedUploads.length);
-    
-    if (successfulUploads === 0 && totalFrames > 0 && !this.data.isCancelling) {
-      wx.showToast({ title: '所有帧分析失败', icon: 'none', duration: 2000 });
-    } else if (successfulUploads === totalFrames && totalFrames > 0) {
-      console.log('[ANALYZE_BATCH] All frames analyzed successfully');
-    }
-    
-    this.selectAndDisplayTopFrames();
-    this.setData({ isCancelling: false });
-  },
-
-  // Retry failed uploads
-  handleRetryFailedUploads: function() {
-    if (!this.data.failedUploads || this.data.failedUploads.length === 0) {
-      wx.showToast({ title: '没有失败的上传', icon: 'none' });
-      return;
-    }
-
-    console.log('[RETRY] Starting retry for', this.data.failedUploads.length, 'failed uploads');
-
-    const framesToRetryInfo = [...this.data.failedUploads];
-    const framesToRetryPaths = framesToRetryInfo.map(f => f.framePath);
-    const poseIdForRetry = framesToRetryInfo[0]?.poseId;
-
-    this.setData({ failedUploads: [] });
-
-    if (framesToRetryPaths.length > 0 && poseIdForRetry) {
-      this.setData({ isProcessingFrames: true });
-
-      // Filter out previous failed attempts
-      const currentResults = this.data.frameAnalysisResults.filter(
-        r => !framesToRetryPaths.includes(r.originalFramePath) || (r.originalFramePath && r.score > 0)
-      );
-      this.setData({ frameAnalysisResults: currentResults });
-
-      this.analyzeFramesBatch(framesToRetryPaths, poseIdForRetry);
-    } else {
-      wx.showToast({ title: '无法重试', icon: 'none' });
-      this.setData({ isProcessingFrames: false });
-    }
-  },
-
-  // Select and display top 3 frames
-  selectAndDisplayTopFrames: function() {
-    if (this.data.isCancelling) {
-      this.setData({ isProcessingFrames: false, isCancelling: false, topThreeFrames: [] });
-      return;
-    }
-
-    const results = this.data.frameAnalysisResults;
-    this.setData({ isProcessingFrames: false });
-
-    if (!results || results.length === 0) {
-      this.setData({ topThreeFrames: [] });
-      return;
-    }
-
-    const validResults = results.filter(r => 
-      r && typeof r.score === 'number' && r.score > 0 && r.skeletonUrl && !r.wasAborted
-    );
-    
-    if (validResults.length === 0) {
-      this.setData({ topThreeFrames: [] });
-      if (results.filter(r => !r.wasAborted).length > 0) {
-        wx.showToast({ title: '未选出足够评分的帧', icon: 'none' });
-      }
-      return;
-    }
-
-    validResults.sort((a, b) => b.score - a.score);
-    const topFrames = validResults.slice(0, 3);
-
-    this.setData({ topThreeFrames: topFrames });
-    console.log('[TOP_FRAMES] Selected top 3 frames:', topFrames);
-
-    if (topFrames.length > 0) {
-      wx.showToast({ 
-        title: `最佳 ${topFrames.length} 帧已显示`, 
-        icon: 'success', 
-        duration: 2000 
-      });
-    }
-    this.setData({ isCancelling: false });
-  },
-
-  // Process video for frame extraction
-  processVideoForFrames: function(videoPath) {
-    console.log('[PROCESS_VIDEO] Starting processing for:', videoPath);
-    
-    this.setData({ 
-      isProcessingFrames: true, 
-      topThreeFrames: [], 
-      frameAnalysisResults: [],
-      isCancelling: false, 
-      currentUploadTasks: []
-    });
-    
-    wx.showLoading({ title: '准备视频分析...', mask: true });
-    
-    this.initializeFrameExtractionResources();
-    this.setData({ extractorVideoSrc: videoPath });
-  },
-
-  // Main upload and score function
-  async uploadAndScore() {
-    if (!this.data.recordedVideo) {
-      wx.showToast({ title: '请先录制视频', icon: 'none' });
-      return;
-    }
-
-    console.log('[MAIN] Starting upload and score process');
-
-    this.setData({
-      isProcessingFrames: true,
-      topThreeFrames: [],
-      frameAnalysisResults: [],
-      isCancelling: false,
-      currentUploadTasks: [],
-      failedUploads: []
-    });
-
-    wx.showLoading({ title: '处理准备中...', mask: true });
-
-    try {
-      await this.processVideoForFrames(this.data.recordedVideo);
-    } catch (error) {
-      console.error('[MAIN] Error starting video processing:', error);
-      this.setData({ isProcessingFrames: false, isCancelling: false });
-      wx.hideLoading();
-      wx.showToast({ title: '处理启动失败', icon: 'none' });
-    }
-  },
-
-  // Page lifecycle: Load sequence data
-  onLoad: function (options) {
-    const level = options.level || 'beginner';
-    this.setData({ level: level });
-    this.loadSequenceData(level);
-  },
-
-  // Load sequence data
-  async loadSequenceData(level) {
-    console.log('[LOAD] Loading sequence for level:', level);
-    this.setData({ loading: true, error: null });
-    wx.showLoading({ title: '加载中...' });
-    
-    try {
-      const sequenceData = await cloudSequenceService.getProcessedSequence(level);
-      
-      if (sequenceData && sequenceData.poses && sequenceData.poses.length > 0) {
-        const initialState = sequenceService.setSequence(sequenceData);
-        this.setData({
-          ...initialState, 
-          loading: false
-        });
-        wx.hideLoading();
-        wx.setNavigationBarTitle({ 
-          title: `${getText(initialState.currentSequence.name)} - ${initialState.currentPoseIndex + 1}/${initialState.currentSequence.poses.length}` 
-        });
-      } else {
-        console.error('[LOAD] Invalid sequence data:', sequenceData);
-        throw new Error('加载的序列数据无效');
-      }
-    } catch (err) {
-      console.error('[LOAD] Failed to load sequence:', err);
-      let userErrorMessage = '无法加载序列数据，请稍后重试。';
-      let toastMessage = '加载失败，请稍后重试';
-
-      if (err && err.message === 'MISSING_SIGNED_URL') {
-        userErrorMessage = '序列配置获取失败，请检查网络或稍后重试。';
-        toastMessage = '序列配置获取失败';
-      }
-      
-      this.setData({ 
-        loading: false, 
-        error: userErrorMessage, 
-        currentSequence: null 
-      });
-      wx.hideLoading();
-      wx.showToast({ title: toastMessage, icon: 'none' });
-      wx.setNavigationBarTitle({ title: '加载错误' });
-    }
-  },
-
-  // Timer management
-  startTimer: function () {
-    if (this.data.timerId) clearInterval(this.data.timerId);
-
-    const timerId = setInterval(() => {
+  startTimer() {
+    this.stopTimer()
+    this.data.timerId = setInterval(() => {
       if (this.data.timeRemaining > 0) {
-        this.setData({ timeRemaining: this.data.timeRemaining - 1 });
+        this.setData({ timeRemaining: this.data.timeRemaining - 1 })
       } else {
-        clearInterval(this.data.timerId);
-        this.setData({ timerId: null });
-        if (this.data.isPlaying) {
-          this.handleNext();
-        }
+        this.handleNext()
       }
-    }, 1000);
-    this.setData({ timerId: timerId });
+    }, 1000)
   },
 
-  stopTimer: function () {
+  stopTimer() {
     if (this.data.timerId) {
-      clearInterval(this.data.timerId);
-      this.setData({ timerId: null });
+      clearInterval(this.data.timerId)
+      this.data.timerId = null
     }
   },
 
-  // Play audio guidance
-  playAudioGuidance: function (src) {
-    return new Promise((resolve, reject) => {
-      if (!src) {
-        console.warn('[AUDIO] No audio src provided');
-        reject(new Error("No audio src provided"));
-        return;
-      }
-
-      const audioCtx = wx.createInnerAudioContext({ useWebAudioImplement: false });
-      audioCtx.src = src;
-      audioCtx.onEnded(() => { 
-        audioCtx.destroy(); 
-        resolve(); 
-      });
-      audioCtx.onError((error) => {
-        console.error('[AUDIO] Error playing:', src, error);
-        wx.showToast({ title: '音频播放失败', icon: 'none' });
-        audioCtx.destroy();
-        reject(error);
-      });
-      audioCtx.play();
-    });
+  playAudio(src) {
+    if (!src) return
+    if (!this.data.audioCtx) {
+      this.data.audioCtx = wx.createInnerAudioContext({ useWebAudioImplement: false })
+    }
+    const ctx = this.data.audioCtx
+    ctx.src = src
+    ctx.play()
   },
 
-  // Navigation handlers
-  handleBack: function () {
-    this.stopTimer();
-    wx.navigateBack();
+  togglePlayPause() {
+    if (this.data.isPlaying) {
+      this.stopTimer()
+      if (this.data.audioCtx) this.data.audioCtx.pause()
+      this.setData({ isPlaying: false })
+    } else {
+      const pose = this.data.sequence.poses[this.data.index]
+      this.playAudio(pose.audioGuide)
+      this.startTimer()
+      this.setData({ isPlaying: true })
+    }
   },
 
-  handleNext: function () {
-    this.stopTimer();
-    const { currentSequence, currentPoseIndex } = this.data;
-    const nextState = sequenceService.nextPose(currentSequence, currentPoseIndex);
-
-    if (nextState) {
+  handleNext() {
+    this.stopTimer()
+    if (this.data.index < this.data.sequence.poses.length - 1) {
+      const nextIndex = this.data.index + 1
+      const pose = this.data.sequence.poses[nextIndex]
       this.setData({
-        currentPoseIndex: nextState.currentPoseIndex_new,
-        timeRemaining: nextState.timeRemaining_new
-      });
-      wx.setNavigationBarTitle({ 
-        title: `${getText(currentSequence.name)} - ${nextState.currentPoseIndex_new + 1}/${currentSequence.poses.length}` 
-      });
-      
-      if (this.data.isPlaying) {
-        const newCurrentPose = currentSequence.poses[nextState.currentPoseIndex_new];
-        this.playAudioGuidance(newCurrentPose.audioGuide)
-          .catch(e => console.error("[AUDIO] Error in handleNext:", e));
-        this.startTimer();
-      }
+        index: nextIndex,
+        timeRemaining: pose.duration,
+        isPlaying: false
+      })
+      wx.setNavigationBarTitle({
+        title: `${this.data.sequence.name.zh} - ${nextIndex + 1}/${this.data.sequence.poses.length}`
+      })
     } else {
-      wx.showToast({ title: '序列完成!', icon: 'success' });
-      setTimeout(() => wx.redirectTo({ url: '/pages/index/index' }), 1500);
+      wx.showToast({ title: '序列完成', icon: 'success' })
+      wx.navigateBack({ delta: 1 })
     }
   },
 
-  // Toggle play/pause
-  togglePlayPause: function () {
-    const { isPlaying_new } = sequenceService.togglePlayPause(this.data.isPlaying);
-    this.setData({ isPlaying: isPlaying_new });
-
-    if (isPlaying_new) {
-      const currentPose = this.data.currentSequence.poses[this.data.currentPoseIndex];
-      this.playAudioGuidance(currentPose.audioGuide)
-        .catch(e => console.error("[AUDIO] Error in togglePlayPause:", e));
-      this.startTimer();
-    } else {
-      this.stopTimer();
-    }
+  handleBack() {
+    this.stopTimer()
+    if (this.data.audioCtx) this.data.audioCtx.stop()
+    wx.navigateBack()
   },
 
-  // Video selection handler
-  handleChooseOrRecordVideo: function() {
-    wx.chooseVideo({
-      sourceType: ['album', 'camera'],
-      compressed: false,
-      maxDuration: 15,
-      camera: 'back',
-      success: (res) => {
-        console.log("[VIDEO] Selected/recorded:", res);
-        this.handleVideoValidation(res);
-      },
-      fail: (err) => {
-        console.error("[VIDEO] wx.chooseVideo failed:", err);
-        if (err.errMsg && err.errMsg.includes('cancel')) {
-          wx.showToast({ title: '操作取消', icon: 'none' });
-        } else {
-          wx.showToast({ title: '选取视频失败', icon: 'none' });
-        }
-      }
-    });
-  },
-
-  // Video validation
-  handleVideoValidation: function(videoDetails) {
-    console.log("[VALIDATION] Checking video:", videoDetails);
-
-    if (videoDetails.duration > 15.5) {
-      wx.showModal({ 
-        title: '视频过长', 
-        content: '您选择的视频超过15秒，请重新选取或录制一个较短的视频。', 
-        showCancel: false, 
-        confirmText: '知道了'
-      });
-      return;
-    }
-
-    const MAX_SIZE_BYTES = 10 * 1024 * 1024; // 10MB
-    if (videoDetails.size > MAX_SIZE_BYTES) {
-      wx.showModal({ 
-        title: '视频文件过大', 
-        content: '您选择的视频超过10MB，请重新选取或录制一个较小的视频。', 
-        showCancel: false, 
-        confirmText: '知道了'
-      });
-      return;
-    }
-
-    console.log("[VALIDATION] Video passed validation");
-    this.setData({
-      recordedVideo: videoDetails.tempFilePath,
-      topThreeFrames: [],
-      frameAnalysisResults: [],
-      failedUploads: []
-    });
-    this.uploadAndScore();
-  },
-
-  // Image error handler - use placeholder
-  onImageError: function(e) {
-    const dataset = e.currentTarget.dataset;
-    const imageType = dataset.type;
-    const imageIndex = dataset.index;
-    
-    console.warn('[IMAGE_ERROR] Failed to load image:', e.detail.errMsg, 'Type:', imageType, 'Index:', imageIndex);
-    
-    // Update the specific image that failed based on type
-    if (imageType === 'pose') {
-      // Update current pose image
-      if (this.data.currentSequence && this.data.currentSequence.poses[this.data.currentPoseIndex]) {
-        this.setData({
-          [`currentSequence.poses[${this.data.currentPoseIndex}].image_url`]: DEFAULT_POSE_IMAGE
-        });
-      }
-    } else if (imageType === 'skeleton' && imageIndex !== undefined) {
-      // Update skeleton image in topThreeFrames
-      const frameIndex = parseInt(imageIndex);
-      if (!isNaN(frameIndex) && this.data.topThreeFrames[frameIndex]) {
-        this.setData({
-          [`topThreeFrames[${frameIndex}].skeletonUrl`]: DEFAULT_POSE_IMAGE
-        });
-      }
-    }
-  },
-
-  // Lifecycle hooks
-  onHide: function () {
-    this.stopTimer();
-  },
-
-  onUnload: function () {
-    this.stopTimer();
-    // Cancel any ongoing uploads
-    if (this.data.currentUploadTasks && this.data.currentUploadTasks.length > 0) {
-      console.log('[UNLOAD] Cancelling', this.data.currentUploadTasks.length, 'ongoing uploads');
-      this.data.currentUploadTasks.forEach(task => {
-        if (task && typeof task.abort === 'function') {
-          task.abort();
-        }
-      });
-    }
+  onUnload() {
+    this.stopTimer()
+    if (this.data.audioCtx) this.data.audioCtx.destroy()
   }
-});
+})

--- a/smartyoga-miniprogram/pages/sequence/index.wxml
+++ b/smartyoga-miniprogram/pages/sequence/index.wxml
@@ -1,164 +1,20 @@
-<view class="container">
-  <!-- Loading State -->
-  <view wx:if="{{loading}}" class="loadingContainer">
-    <text class="loadingText">加载中...</text>
-    <!-- Add a custom loading animation here if desired -->
+<!-- 序列页仅保留体式展示与播放控制，已移除拍摄与上传相关功能 -->
+<view class="container" wx:if="{{sequence}}">
+  <view class="header">
+    <view bindtap="handleBack" class="backButton"><text class="backButtonText">←</text></view>
+    <text class="headerTitle">{{sequence.name.zh}} - {{index + 1}}/{{sequence.poses.length}}</text>
+    <view class="placeholderView" />
   </view>
 
-  <!-- Error State (Simplified) -->
-  <view wx:elif="{{error}}" class="errorContainer">
-    <text class="errorText">{{error}}</text>
-    <button bindtap="loadSequenceData" data-level="{{level}}">重试</button>
+  <view class="poseContainer">
+    <image class="poseImg" src="{{sequence.poses[index].image_url}}" mode="aspectFit" />
+    <text class="poseName">{{sequence.poses[index].displayName || sequence.poses[index].name.zh}}</text>
+    <text class="poseInstructions">{{sequence.poses[index].instructions.zh}}</text>
+    <text class="timerText">{{timeRemaining}}s</text>
   </view>
 
-  <!-- Main Content -->
-  <block wx:else>
-    <view class="header">
-      <view bindtap="handleBack" class="backButton">
-        <text class="backButtonText">←</text>
-      </view>
-      <text class="headerTitle">{{currentSequence.name.zh}} - {{currentPoseIndex + 1}}/{{currentSequence.poses.length}}</text>
-      <view class="placeholderView" />
-    </view>
-
-    <view class="poseContainer">
-      <image 
-        class="poseImg" 
-        src="{{currentSequence.poses[currentPoseIndex].image_url}}" 
-        mode="aspectFit"
-        binderror="onImageError"
-      />
-      <text class="poseName">{{currentSequence.poses[currentPoseIndex].displayName || currentSequence.poses[currentPoseIndex].name.zh}}</text>
-      <text class="poseInstructions">{{currentSequence.poses[currentPoseIndex].instructions.zh}}</text>
-      <text class="timerText">{{timeRemaining}}s</text>
-    </view>
-    <!-- Skeleton Image Display Area -->
-    <image wx:if="{{skeletonUrl}}" class="skeletonImg" src="{{skeletonUrl}}" mode="widthFix"/>
-
-    <view class="controlsContainer">
-      <view bindtap="togglePlayPause" class="controlButton">
-        <text class="controlButtonText">{{isPlaying ? '❚❚' : '▶'}}</text>
-      </view>
-      <view bindtap="handleNext" class="controlButton">
-        <text class="controlButtonText">▶▶</text>
-      </view>
-      <button class="camBtn" bindtap="handleCameraPress">
-        <image src="/assets/images/cam.png" class="camIcon"/>
-      </button>
-      <!-- New Upload/Record Video Button -->
-      <button bindtap="handleChooseOrRecordVideo" class="controlButton control-btn upload-btn">
-        <text class="controlButtonText">上传/录制视频</text>
-      </button>
-    </view>
-  </block>
-
-  <!-- Camera Modal -->
-  <view wx:if="{{showCamera}}" class="modalOverlay">
-    <view class="cameraModalContainer">
-      <view class="cameraHeader">
-        <text class="cameraTitle">录制您的体式</text>
-        <button bindtap="toggleCamera" class="cameraToggleButton">⇆</button>
-        <view bindtap="closeCamera" class="closeButton">
-          <text class="closeButtonText">X</text>
-        </view>
-      </view>
-      <camera 
-        id="myCamera" 
-        device-position="{{cameraPosition}}" 
-        flash="off" 
-        binderror="cameraError" 
-        class="cameraView"
-        style="width:100%; height: 300px;"
-      ></camera>
-      
-      <view wx:if="{{!recordedVideo}}">
-        <button wx:if="{{!isRecording}}" bindtap="startRecording" class="cameraActionButton">开始录制</button>
-        <button wx:else bindtap="stopRecording" class="cameraActionButton recording">停止录制</button>
-      </view>
-      
-      <view wx:if="{{recordedVideo}}" class="videoPreviewContainer">
-        <text class="previewText">视频已录制:</text>
-        <!-- Mini Program doesn't have a direct video player for temp files like this in WXML easily -->
-        <!-- Usually, you'd upload it then play the remote URL, or use a more complex setup -->
-        <text class="videoPathText">路径: {{recordedVideo}}</text>
-        <view class="videoActions">
-          <button 
-            bindtap="uploadAndScore" 
-            class="cameraActionButton"
-            disabled="{{isProcessingFrames}}">
-            {{isProcessingFrames ? '处理中...' : '上传评分'}}
-          </button>
-          <button 
-            bindtap="retakeVideo" 
-            class="cameraActionButton secondary"
-            disabled="{{isProcessingFrames}}">
-            重新录制
-          </button>
-        </view>
-      </view>
-      <view wx:if="{{isUploading && !isProcessingFrames}}" class="uploadingIndicator"> <!-- Ensure old indicator doesn't overlap if isUploading is still used elsewhere -->
-        <text>上传中...</text>
-      </view>
-
-      <!-- Frame Processing Indicator -->
-      <view wx:if="{{isProcessingFrames}}" class="frameProcessingIndicator">
-        <text>正在提取和分析帧...</text>
-        <!-- Optional: Add a wx:for loop here if you plan to show individual frame progress -->
-      </view>
-    </view>
-  </view>
-
-  <!-- Hidden elements for frame extraction -->
-  <video
-    id="frameExtractorVideo"
-    src="{{recordedVideo}}" 
-    style="display: none; width: 1px; height: 1px; position: absolute; top: -1000px; left: -1000px;"
-    bindloadedmetadata="onVideoLoadMetadata"
-    bindtimeupdate="onVideoTimeUpdate"
-  ></video>
-  <canvas
-    canvas-id="frameExtractorCanvas"
-    id="frameExtractorCanvas"
-    style="width:480px; height:320px; opacity:0; position:absolute; left:-9999px; top:-9999px;"
-  ></canvas>
-
-  <!-- Score Modal -->
-  <view wx:if="{{showScoreModal}}" class="modalOverlay">
-    <view class="scoreModalContainer">
-      <text class="scoreModalTitle">体式评分</text>
-      <view class="scoreDisplay">
-        <text class="scoreText">{{poseScore ? poseScore.score : 'N/A'}} / 100</text>
-        <text class="scoreFeedback">{{poseScore ? poseScore.feedback : ''}}</text>
-      </view>
-      <!-- Skeleton Image for Score Modal -->
-      <image 
-        wx:if="{{scoreSkeletonImageUrl}}" 
-        src="{{scoreSkeletonImageUrl}}" 
-        style="width:90%; margin:12px auto; display:block;" 
-        mode="widthFix"
-        binderror="onScoreSkeletonImageError"
-        class="scoreSkeletonImage" 
-      />
-      <text wx:if="{{!scoreSkeletonImageUrl && showScoreModal}}" class="noSkeletonImageText">
-        No skeleton image available.
-      </text>
-       <!-- Example: Star rating based on score -->
-      <view class="starRating">
-        <text wx:for="{{5}}" wx:key="*this" class="star {{index < (poseScore.score / 20) ? 'filled' : ''}}">★</text>
-      </view>
-      <button bindtap="closeScoreModal" class="cameraActionButton">关闭</button>
-    </view>
-  </view>
-
-  <!-- Top 3 Scored Frames Display -->
-  <view wx:if="{{topThreeFrames && topThreeFrames.length > 0}}" class="topFramesContainer">
-    <text class="topFramesTitle">最佳帧分析结果</text>
-    <view wx:for="{{topThreeFrames}}" wx:key="index" class="frameResultItem">
-      <image class="frameSkeletonImage" src="{{item.skeletonUrl}}" mode="aspectFit" />
-      <view class="frameInfo">
-        <text class="frameScore">评分: {{item.score}}</text>
-        <text class="frameFeedback">AI建议: {{item.feedback}}</text>
-      </view>
-    </view>
+  <view class="controlsContainer">
+    <view bindtap="togglePlayPause" class="controlButton"><text class="controlButtonText">{{isPlaying ? '❚❚' : '▶'}}</text></view>
+    <view bindtap="handleNext" class="controlButton"><text class="controlButtonText">▶▶</text></view>
   </view>
 </view>

--- a/smartyoga-miniprogram/pages/sequence/index.wxss
+++ b/smartyoga-miniprogram/pages/sequence/index.wxss
@@ -1,43 +1,17 @@
-/* General Container Styles */
+/* 仅保留体式展示和播放控制的基本样式 */
 .container {
   display: flex;
   flex-direction: column;
-  flex: 1;
+  height: 100vh;
   background-color: #FAFAFA;
-  height: 100vh; /* Ensure full height */
-  box-sizing: border-box;
 }
 
-/* Loading and Error States */
-.loadingContainer, .errorContainer {
-  display: flex;
-  flex: 1;
-  justify-content: center;
-  align-items: center;
-  padding: 20px;
-}
-.loadingText, .errorText {
-  font-size: 18px;
-  color: #555;
-}
-.errorContainer button { /* Basic button styling */
-  margin-top: 15px;
-  padding: 10px 20px;
-  background-color: #8B5CF6;
-  color: white;
-  border-radius: 5px;
-}
-
-/* Header */
 .header {
   display: flex;
-  flex-direction: row;
   align-items: center;
   padding: 16px 20px;
   background-color: #FFF;
-  border-bottom-width: 1px;
-  border-bottom-style: solid;
-  border-bottom-color: #E2E8F0;
+  border-bottom: 1px solid #E2E8F0;
 }
 .backButton {
   padding: 8px;
@@ -48,31 +22,28 @@
 }
 .headerTitle {
   flex: 1;
-  font-size: 17px; /* Adjusted from 18px to better fit typical MP nav */
+  text-align: center;
+  font-size: 17px;
   font-weight: 600;
   color: #2D3748;
-  text-align: center;
 }
-.placeholderView { /* To balance the back button for centering title */
-  width: 40px; 
+.placeholderView {
+  width: 40px;
   height: 24px;
 }
 
-/* Pose Display */
 .poseContainer {
   flex: 1;
   display: flex;
   flex-direction: column;
   align-items: center;
-  justify-content: center; /* Center content vertically */
+  justify-content: center;
   padding: 20px;
 }
-.poseImg, .skeletonImg {
+.poseImg {
   width: 100%;
-  max-width: 360px; /* Added max-width for better control on larger screens */
-  height: auto;     /* Ensures aspect ratio is maintained with width adjustments */
-  display: block;   /* Allows margin auto to work for centering */
-  margin: 0 auto 16px auto; /* Centers the block and adds bottom margin */
+  max-width: 360px;
+  margin-bottom: 16px;
 }
 .poseName {
   font-size: 24px;
@@ -86,8 +57,6 @@
   color: #4A5568;
   text-align: center;
   margin-bottom: 15px;
-  max-height: 100px; /* Limit instruction height */
-  overflow-y: auto; /* Scroll for long instructions */
 }
 .timerText {
   font-size: 36px;
@@ -96,304 +65,25 @@
   margin-bottom: 20px;
 }
 
-/* Controls */
 .controlsContainer {
   display: flex;
-  flex-direction: row;
   justify-content: space-around;
-  align-items: center;
   padding: 20px;
   background-color: #FFF;
-  border-top-width: 1px;
-  border-top-style: solid;
-  border-top-color: #E2E8F0;
-  flex-wrap: wrap; /* Allow wrapping for multiple buttons */
-  gap: 10px; /* Space between buttons */
+  border-top: 1px solid #E2E8F0;
 }
 .controlButton {
   padding: 15px 25px;
-  background-color: #F0F0F0; /* Lighter for non-primary buttons */
-  border-radius: 30px; /* Circular/pill shape */
-  border: none;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  background-color: #F0F0F0;
+  border-radius: 30px;
 }
 .controlButtonText {
-  font-size: 20px; /* Adjust for icon-like text */
+  font-size: 20px;
   color: #333;
 }
-/* Highlight for main play/pause button */
-.controlButton:nth-child(1) { 
+.controlButton:first-child {
   background-color: #8B5CF6;
 }
-.controlButton:nth-child(1) .controlButtonText {
+.controlButton:first-child .controlButtonText {
   color: #FFF;
-}
-
-/* Specific styles for control-btn and upload-btn */
-.control-btn {
-  padding: 12px 20px;
-  background-color: #F0F0F0;
-  border-radius: 25px;
-  transition: background-color 0.2s ease;
-}
-.control-btn:active {
-  background-color: #E0E0E0;
-}
-.upload-btn {
-  background-color: #10B981; /* Green color for upload button */
-  flex: 1;
-  max-width: 180px;
-  min-width: 140px;
-}
-.upload-btn .controlButtonText {
-  color: #FFF;
-  font-size: 16px;
-  font-weight: 500;
-}
-
-.camBtn {
-  background: none;
-  border: none;
-  padding: 10px 15px; /* Keep similar padding to other control buttons for touch area */
-  margin: 0 15px;   /* Keep similar margin */
-  line-height: 1;   /* Helps if there's any residual text height */
-}
-
-.camIcon {
-  width: 32px;
-  height: 32px;
-  display: block; 
-}
-
-/* Modal Styles */
-.modalOverlay {
-  position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.6);
-  display: flex;
-  justify-content: center;
-  align-items: center;
-  z-index: 1000;
-}
-
-/* Camera Modal */
-.cameraModalContainer {
-  width: 90%;
-  max-width: 500px;
-  background-color: #FFF;
-  border-radius: 12px;
-  padding: 20px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-}
-.cameraHeader {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  margin-bottom: 15px;
-}
-.cameraTitle {
-  font-size: 18px;
-  font-weight: bold;
-}
-.cameraToggleButton {
-  background: none;
-  border: 1px solid #8B5CF6;
-  border-radius: 5px;
-  padding: 5px 10px;
-  font-size: 16px;
-  color: #8B5CF6;
-}
-.closeButton {
-  padding: 5px;
-}
-.closeButtonText {
-  font-size: 20px;
-  color: #555;
-}
-.cameraView { /* Style for the camera component itself */
-  width: 100%;
-  height: 300px; /* Default height, can be adjusted */
-  margin-bottom: 15px;
-  background-color: #000; /* Placeholder background */
-}
-.cameraActionButton {
-  display: block; /* Make buttons take full width or style as inline-block */
-  width: 100%;
-  padding: 12px;
-  font-size: 16px;
-  font-weight: 500;
-  color: #FFF;
-  background-color: #8B5CF6;
-  border-radius: 8px;
-  text-align: center;
-  margin-top: 10px;
-  border: none;
-}
-.cameraActionButton.recording {
-  background-color: #EF4444; /* Red for recording */
-}
-.cameraActionButton.secondary {
-  background-color: #A0A0A0;
-}
-.cameraActionButton:disabled {
-  opacity: 0.6;
-  background-color: #C0C0C0;
-}
-.videoPreviewContainer {
-  margin-top: 15px;
-  padding: 10px;
-  background-color: #f3f3f3;
-  border-radius: 8px;
-}
-.previewText {
-  font-size: 14px;
-  color: #333;
-  margin-bottom: 5px;
-}
-.videoPathText {
-  font-size: 12px;
-  color: #666;
-  word-break: break-all;
-  margin-bottom: 10px;
-}
-.videoActions {
-  display: flex;
-  justify-content: space-between;
-  gap: 10px; /* If gap is not supported, use margins */
-}
-.videoActions .cameraActionButton {
-  flex: 1;
-}
-.uploadingIndicator {
-  margin-top: 10px;
-}
-.uploadingIndicator text{
-  display: block;
-  text-align: center;
-  font-size: 16px;
-  color: #8B5CF6;
-  padding: 10px;
-}
-
-/* Frame Processing Indicator */
-.frameProcessingIndicator {
-  margin-top: 15px;
-  padding: 15px;
-  background-color: #F3F4F6;
-  border-radius: 8px;
-  text-align: center;
-}
-.frameProcessingIndicator text {
-  font-size: 16px;
-  color: #6B7280;
-}
-
-/* Score Modal */
-.scoreModalContainer {
-  width: 80%;
-  max-width: 400px;
-  background-color: #FFF;
-  border-radius: 12px;
-  padding: 25px;
-  box-shadow: 0 4px 12px rgba(0,0,0,0.15);
-  text-align: center;
-}
-.scoreModalTitle {
-  font-size: 20px;
-  font-weight: bold;
-  margin-bottom: 20px;
-}
-.scoreDisplay {
-  margin-bottom: 20px;
-}
-.scoreText {
-  font-size: 36px;
-  font-weight: bold;
-  color: #8B5CF6;
-  margin-bottom: 5px;
-  display: block;
-}
-.scoreFeedback {
-  font-size: 14px;
-  color: #4A5568;
-  line-height: 1.5;
-  display: block;
-}
-.scoreSkeletonImage {
-  border-radius: 8px;
-  box-shadow: 0 2px 8px rgba(0,0,0,0.1);
-}
-.noSkeletonImageText {
-  font-size: 14px;
-  color: #9CA3AF;
-  margin: 20px 0;
-  display: block;
-}
-.starRating {
-  font-size: 24px; /* Size of stars */
-  margin-bottom: 25px;
-}
-.star {
-  color: #D1D5DB; /* Empty star color */
-  margin: 0 2px;
-  display: inline-block;
-}
-.star.filled {
-  color: #FBBF24; /* Filled star color */
-}
-/* Use cameraActionButton style for close button in score modal too */
-.scoreModalContainer .cameraActionButton {
-  background-color: #6B7280; /* A neutral color for "Close" */
-}
-
-/* Top Frames Container */
-.topFramesContainer {
-  padding: 20px;
-  background-color: #FFF;
-  margin-top: 10px;
-}
-.topFramesTitle {
-  font-size: 18px;
-  font-weight: bold;
-  color: #2D3748;
-  margin-bottom: 15px;
-  display: block;
-}
-.frameResultItem {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  padding: 15px;
-  background-color: #F9FAFB;
-  border-radius: 8px;
-  margin-bottom: 10px;
-  box-shadow: 0 1px 3px rgba(0,0,0,0.1);
-}
-.frameSkeletonImage {
-  width: 80px;
-  height: 80px;
-  border-radius: 8px;
-  margin-right: 15px;
-  object-fit: cover;
-}
-.frameInfo {
-  flex: 1;
-}
-.frameScore {
-  font-size: 16px;
-  font-weight: 600;
-  color: #8B5CF6;
-  margin-bottom: 5px;
-  display: block;
-}
-.frameFeedback {
-  font-size: 14px;
-  color: #4A5568;
-  line-height: 1.4;
-  display: block;
 }


### PR DESCRIPTION
## Summary
- keep only homepage, meditation, sequence, photo detection and result pages
- remove camera and upload logic from other pages
- simplify sequence page to show poses only
- register photo detect and result pages in app config
- adjust retry link to photo-detect page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684320bc2ce48329a1eda606ea30730c