### PR TITLE
Remove debug printing from angle_config

### DIFF
--- a/backend/angle_config.py
+++ b/backend/angle_config.py
@@ -109,5 +109,3 @@ def infer_keypoints(image_bytes: bytes) -> dict:
     except Exception as e:
         raise NoKeypointError(f"推理失败: {str(e)}")
 
-print("【后端 ANGLE_CONFIG_DATA 支持体式数量】: ", len(ANGLE_CONFIG_DATA))
-print("【后端 ANGLE_CONFIG_DATA 支持体式 key】: ", list(ANGLE_CONFIG_DATA.keys()))


### PR DESCRIPTION
## Summary
- remove ANGLE_CONFIG debug prints from `angle_config.py`
- keep startup prints in `pose_detector.py`

## Testing
- `python backend/test_movenet.py backend/input.jpeg` *(fails: Could not open 'movenet_lightning_float16.tflite')*

------
https://chatgpt.com/codex/tasks/task_e_6845b2f4d4d88329bbf80c78e08f64c5