### PR TITLE
Simplify sequence page with centralized pose images

### DIFF
--- a/smartyoga-miniprogram/assets/images.js
+++ b/smartyoga-miniprogram/assets/images.js
@@ -1,22 +1,24 @@
-export default {
-    boat_pose: '/assets/poses/boat_pose.png',
-    bound_angle_pose: '/assets/poses/bound_angle_pose.png',
-    bridge_pose: '/assets/poses/bridge_pose.png',
-    cat_cow_pose: '/assets/poses/cat_cow_pose.png',
-    chair_pose: '/assets/poses/chair_pose.png',
-    child_pose: '/assets/poses/child_pose.png',
-    corpse_pose: '/assets/poses/corpse_pose.png',
-    dancer_pose: '/assets/poses/dancer_pose.png',
-    downward_dog: '/assets/poses/downward_dog.png',
-    eagle_pose: '/assets/poses/eagle_pose.png',
-    half_moon_pose: '/assets/poses/half_moon_pose.png',
-    mountain_pose: '/assets/poses/mountain_pose.png',
-    plank_pose: '/assets/poses/plank_pose.png',
-    seated_forward_bend: '/assets/poses/seated_forward_bend.png',
-    side_plank_pose: '/assets/poses/side_plank_pose.png',
-    supine_spinal_twist: '/assets/poses/supine_spinal_twist.png',
-    tree_pose: '/assets/poses/tree_pose.png',
-    warrior_i: '/assets/poses/warrior_i.png',
-    warrior_ii: '/assets/poses/warrior_ii.png',
-    warrior_iii: '/assets/poses/warrior_iii.png'
-  };
+const poseImages = {
+  boat_pose: '/assets/poses/boat_pose.png',
+  bound_angle_pose: '/assets/poses/bound_angle_pose.png',
+  bridge_pose: '/assets/poses/bridge_pose.png',
+  cat_cow_pose: '/assets/poses/cat_cow_pose.png',
+  chair_pose: '/assets/poses/chair_pose.png',
+  child_pose: '/assets/poses/child_pose.png',
+  corpse_pose: '/assets/poses/corpse_pose.png',
+  dancer_pose: '/assets/poses/dancer_pose.png',
+  downward_dog: '/assets/poses/downward_dog.png',
+  eagle_pose: '/assets/poses/eagle_pose.png',
+  half_moon_pose: '/assets/poses/half_moon_pose.png',
+  mountain_pose: '/assets/poses/mountain_pose.png',
+  plank_pose: '/assets/poses/plank_pose.png',
+  seated_forward_bend: '/assets/poses/seated_forward_bend.png',
+  side_plank_pose: '/assets/poses/side_plank_pose.png',
+  supine_spinal_twist: '/assets/poses/supine_spinal_twist.png',
+  tree_pose: '/assets/poses/tree_pose.png',
+  warrior_i: '/assets/poses/warrior_i.png',
+  warrior_ii: '/assets/poses/warrior_ii.png',
+  warrior_iii: '/assets/poses/warrior_iii.png'
+};
+
+export default poseImages;

--- a/smartyoga-miniprogram/pages/sequence/index.js
+++ b/smartyoga-miniprogram/pages/sequence/index.js
@@ -1,227 +1,30 @@
-import { uploadFrameForScoring, DEFAULT_POSE_IMAGE } from '../../utils/yoga-api.js';
-const cloudSequenceService = require('../../utils/cloud-sequence-service.js');
-const sequenceService = require('../../utils/sequence-service.js');
-const getText = v => (typeof v === 'object' ? (v.zh || v.en || '') : v);
+import poseImages from '../../assets/images.js';
 
 Page({
   data: {
-    level: '',
-    currentSequence: null,
-    currentPoseIndex: 0,
-    isPlaying: false,
-    timeRemaining: 0,
-    loading: true,
-    error: null,
-    skeletonUrl: null,
-    timerId: null,
-    showScoreModal: false,
-    poseScore: null,
-    scoreSkeletonImageUrl: null,
-    defaultPoseImage: DEFAULT_POSE_IMAGE
-  },
-
-
-
-  // Page lifecycle: Load sequence data
-  onLoad: function (options) {
-    const level = options.level || 'beginner';
-    this.setData({ level: level });
-    this.loadSequenceData(level);
-  },
-
-  // Load sequence data
-  async loadSequenceData(level) {
-    console.log('[LOAD] Loading sequence for level:', level);
-    this.setData({ loading: true, error: null });
-    wx.showLoading({ title: '加载中...' });
-    
-    try {
-      const sequenceData = await cloudSequenceService.getProcessedSequence(level);
-      
-      if (sequenceData && sequenceData.poses && sequenceData.poses.length > 0) {
-        const initialState = sequenceService.setSequence(sequenceData);
-        this.setData({
-          ...initialState, 
-          loading: false
-        });
-        wx.hideLoading();
-        wx.setNavigationBarTitle({ 
-          title: `${getText(initialState.currentSequence.name)} - ${initialState.currentPoseIndex + 1}/${initialState.currentSequence.poses.length}` 
-        });
-      } else {
-        console.error('[LOAD] Invalid sequence data:', sequenceData);
-        throw new Error('加载的序列数据无效');
-      }
-    } catch (err) {
-      console.error('[LOAD] Failed to load sequence:', err);
-      let userErrorMessage = '无法加载序列数据，请稍后重试。';
-      let toastMessage = '加载失败，请稍后重试';
-
-      if (err && err.message === 'MISSING_SIGNED_URL') {
-        userErrorMessage = '序列配置获取失败，请检查网络或稍后重试。';
-        toastMessage = '序列配置获取失败';
-      }
-      
-      this.setData({ 
-        loading: false, 
-        error: userErrorMessage, 
-        currentSequence: null 
-      });
-      wx.hideLoading();
-      wx.showToast({ title: toastMessage, icon: 'none' });
-      wx.setNavigationBarTitle({ title: '加载错误' });
-    }
-  },
-
-  // Timer management
-  startTimer: function () {
-    if (this.data.timerId) clearInterval(this.data.timerId);
-
-    const timerId = setInterval(() => {
-      if (this.data.timeRemaining > 0) {
-        this.setData({ timeRemaining: this.data.timeRemaining - 1 });
-      } else {
-        clearInterval(this.data.timerId);
-        this.setData({ timerId: null });
-        if (this.data.isPlaying) {
-          this.handleNext();
-        }
-      }
-    }, 1000);
-    this.setData({ timerId: timerId });
-  },
-
-  stopTimer: function () {
-    if (this.data.timerId) {
-      clearInterval(this.data.timerId);
-      this.setData({ timerId: null });
-    }
-  },
-
-  // Play audio guidance
-  playAudioGuidance: function (src) {
-    return new Promise((resolve, reject) => {
-      if (!src) {
-        console.warn('[AUDIO] No audio src provided');
-        reject(new Error("No audio src provided"));
-        return;
-      }
-
-      const audioCtx = wx.createInnerAudioContext({ useWebAudioImplement: false });
-      audioCtx.src = src;
-      audioCtx.onEnded(() => { 
-        audioCtx.destroy(); 
-        resolve(); 
-      });
-      audioCtx.onError((error) => {
-        console.error('[AUDIO] Error playing:', src, error);
-        wx.showToast({ title: '音频播放失败', icon: 'none' });
-        audioCtx.destroy();
-        reject(error);
-      });
-      audioCtx.play();
-    });
-  },
-
-  // Navigation handlers
-  handleBack: function () {
-    this.stopTimer();
-    wx.navigateBack();
-  },
-
-  handleNext: function () {
-    this.stopTimer();
-    const { currentSequence, currentPoseIndex } = this.data;
-    const nextState = sequenceService.nextPose(currentSequence, currentPoseIndex);
-
-    if (nextState) {
-      this.setData({
-        currentPoseIndex: nextState.currentPoseIndex_new,
-        timeRemaining: nextState.timeRemaining_new
-      });
-      wx.setNavigationBarTitle({ 
-        title: `${getText(currentSequence.name)} - ${nextState.currentPoseIndex_new + 1}/${currentSequence.poses.length}` 
-      });
-      
-      if (this.data.isPlaying) {
-        const newCurrentPose = currentSequence.poses[nextState.currentPoseIndex_new];
-        this.playAudioGuidance(newCurrentPose.audioGuide)
-          .catch(e => console.error("[AUDIO] Error in handleNext:", e));
-        this.startTimer();
-      }
-    } else {
-      const randomScore = Math.floor(Math.random() * 30) + 70;
-      this.setData({
-        poseScore: { score: randomScore, feedback: '保持呼吸流畅，继续练习' },
-        showScoreModal: true
-      });
-    }
-  },
-
-  closeScoreModal() {
-    this.setData({ showScoreModal: false });
-    wx.redirectTo({ url: '/pages/index/index' });
-  },
-
-  // Toggle play/pause
-  togglePlayPause: function () {
-    const { isPlaying_new } = sequenceService.togglePlayPause(this.data.isPlaying);
-    this.setData({ isPlaying: isPlaying_new });
-
-    if (isPlaying_new) {
-      const currentPose = this.data.currentSequence.poses[this.data.currentPoseIndex];
-      this.playAudioGuidance(currentPose.audioGuide)
-        .catch(e => console.error("[AUDIO] Error in togglePlayPause:", e));
-      this.startTimer();
-    } else {
-      this.stopTimer();
-    }
-  },
-
-
-
-  // Image error handler - use placeholder
-  onImageError: function(e) {
-    const dataset = e.currentTarget.dataset;
-    const imageType = dataset.type;
-    const imageIndex = dataset.index;
-    
-    console.warn('[IMAGE_ERROR] Failed to load image:', e.detail.errMsg, 'Type:', imageType, 'Index:', imageIndex);
-    
-    // Update the specific image that failed based on type
-    if (imageType === 'pose') {
-      // Update current pose image
-      if (this.data.currentSequence && this.data.currentSequence.poses[this.data.currentPoseIndex]) {
-        this.setData({
-          [`currentSequence.poses[${this.data.currentPoseIndex}].image_url`]: DEFAULT_POSE_IMAGE
-        });
-      }
-    } else if (imageType === 'skeleton' && imageIndex !== undefined) {
-      // Update skeleton image in topThreeFrames
-      const frameIndex = parseInt(imageIndex);
-      if (!isNaN(frameIndex) && this.data.topThreeFrames[frameIndex]) {
-        this.setData({
-          [`topThreeFrames[${frameIndex}].skeletonUrl`]: DEFAULT_POSE_IMAGE
-        });
-      }
-    }
-  },
-
-  // Lifecycle hooks
-  onHide: function () {
-    this.stopTimer();
-  },
-
-  onUnload: function () {
-    this.stopTimer();
-    // Cancel any ongoing uploads
-    if (this.data.currentUploadTasks && this.data.currentUploadTasks.length > 0) {
-      console.log('[UNLOAD] Cancelling', this.data.currentUploadTasks.length, 'ongoing uploads');
-      this.data.currentUploadTasks.forEach(task => {
-        if (task && typeof task.abort === 'function') {
-          task.abort();
-        }
-      });
-    }
+    poseImages,
+    poses: [
+      { key: 'boat_pose', name: 'Boat Pose' },
+      { key: 'bound_angle_pose', name: 'Bound Angle Pose' },
+      { key: 'bridge_pose', name: 'Bridge Pose' },
+      { key: 'cat_cow_pose', name: 'Cat Cow Pose' },
+      { key: 'chair_pose', name: 'Chair Pose' },
+      { key: 'child_pose', name: 'Child Pose' },
+      { key: 'corpse_pose', name: 'Corpse Pose' },
+      { key: 'dancer_pose', name: 'Dancer Pose' },
+      { key: 'downward_dog', name: 'Downward Dog' },
+      { key: 'eagle_pose', name: 'Eagle Pose' },
+      { key: 'half_moon_pose', name: 'Half Moon Pose' },
+      { key: 'mountain_pose', name: 'Mountain Pose' },
+      { key: 'plank_pose', name: 'Plank Pose' },
+      { key: 'seated_forward_bend', name: 'Seated Forward Bend' },
+      { key: 'side_plank_pose', name: 'Side Plank Pose' },
+      { key: 'supine_spinal_twist', name: 'Supine Spinal Twist' },
+      { key: 'tree_pose', name: 'Tree Pose' },
+      { key: 'warrior_i', name: 'Warrior I' },
+      { key: 'warrior_ii', name: 'Warrior II' },
+      { key: 'warrior_iii', name: 'Warrior III' }
+    ]
   }
 });
+

--- a/smartyoga-miniprogram/pages/sequence/index.wxml
+++ b/smartyoga-miniprogram/pages/sequence/index.wxml
@@ -1,79 +1,9 @@
 <view class="container">
-  <!-- Loading State -->
-  <view wx:if="{{loading}}" class="loadingContainer">
-    <text class="loadingText">加载中...</text>
-    <!-- Add a custom loading animation here if desired -->
-  </view>
-
-  <!-- Error State (Simplified) -->
-  <view wx:elif="{{error}}" class="errorContainer">
-    <text class="errorText">{{error}}</text>
-    <button bindtap="loadSequenceData" data-level="{{level}}">重试</button>
-  </view>
-
-  <!-- Main Content -->
-  <block wx:else>
-    <view class="header">
-      <view bindtap="handleBack" class="backButton">
-        <text class="backButtonText">←</text>
-      </view>
-      <text class="headerTitle">{{currentSequence.name.zh}} - {{currentPoseIndex + 1}}/{{currentSequence.poses.length}}</text>
-      <view class="placeholderView" />
-    </view>
-
-    <view class="poseContainer">
-      <image 
-        class="poseImg" 
-        src="{{currentSequence.poses[currentPoseIndex].image_url}}" 
-        mode="aspectFit"
-        binderror="onImageError"
-      />
-      <text class="poseName">{{currentSequence.poses[currentPoseIndex].displayName || currentSequence.poses[currentPoseIndex].name.zh}}</text>
-      <text class="poseInstructions">{{currentSequence.poses[currentPoseIndex].instructions.zh}}</text>
-      <text class="timerText">{{timeRemaining}}s</text>
-    </view>
-    <!-- Skeleton Image Display Area -->
-    <image wx:if="{{skeletonUrl}}" class="skeletonImg" src="{{skeletonUrl}}" mode="widthFix"/>
-
-    <view class="controlsContainer">
-      <view bindtap="togglePlayPause" class="controlButton">
-        <text class="controlButtonText">{{isPlaying ? '❚❚' : '▶'}}</text>
-      </view>
-      <view bindtap="handleNext" class="controlButton">
-        <text class="controlButtonText">▶▶</text>
-      </view>
-      <!-- 控制按钮保留播放与下一步 -->
-    </view>
-  </block>
-
-
-
-  <!-- Score Modal -->
-  <view wx:if="{{showScoreModal}}" class="modalOverlay">
-    <view class="scoreModalContainer">
-      <text class="scoreModalTitle">体式评分</text>
-      <view class="scoreDisplay">
-        <text class="scoreText">{{poseScore ? poseScore.score : 'N/A'}} / 100</text>
-        <text class="scoreFeedback">{{poseScore ? poseScore.feedback : ''}}</text>
-      </view>
-      <!-- Skeleton Image for Score Modal -->
-      <image 
-        wx:if="{{scoreSkeletonImageUrl}}" 
-        src="{{scoreSkeletonImageUrl}}" 
-        style="width:90%; margin:12px auto; display:block;" 
-        mode="widthFix"
-        binderror="onScoreSkeletonImageError"
-        class="scoreSkeletonImage" 
-      />
-      <text wx:if="{{!scoreSkeletonImageUrl && showScoreModal}}" class="noSkeletonImageText">
-        No skeleton image available.
-      </text>
-       <!-- Example: Star rating based on score -->
-      <view class="starRating">
-        <text wx:for="{{5}}" wx:key="*this" class="star {{index < (poseScore.score / 20) ? 'filled' : ''}}">★</text>
-      </view>
-      <button bindtap="closeScoreModal" class="cameraActionButton">关闭</button>
+  <view class="pose-list">
+    <view wx:for="{{poses}}" wx:key="{{item.key}}" class="pose-item">
+      <image class="pose-image" src="{{poseImages[item.key]}}" mode="aspectFit" />
+      <text class="pose-name">{{item.name}}</text>
     </view>
   </view>
-
 </view>
+


### PR DESCRIPTION
## Summary
- centralize pose image paths in `assets/images.js`
- simplify `pages/sequence/index.js` to render a pose list
- render poses in `index.wxml` using `wx:for`

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_6845fd1a155883299332d7201bf90f4b