### PR TITLE
Add pose image previews

### DIFF
--- a/smartyoga-miniprogram/assets/images.js
+++ b/smartyoga-miniprogram/assets/images.js
@@ -1,4 +1,4 @@
-export default {
+const poseImages = {
   boat_pose: '/assets/poses/boat_pose.png',
   bound_angle_pose: '/assets/poses/bound_angle_pose.png',
   bridge_pose: '/assets/poses/bridge_pose.png',
@@ -20,3 +20,6 @@ export default {
   warrior_ii: '/assets/poses/warrior_ii.png',
   warrior_iii: '/assets/poses/warrior_iii.png'
 };
+
+export default poseImages;
+export { poseImages };

--- a/smartyoga-miniprogram/pages/sequence/index.js
+++ b/smartyoga-miniprogram/pages/sequence/index.js
@@ -1,4 +1,5 @@
 import { uploadFrameForScoring, DEFAULT_POSE_IMAGE } from '../../utils/yoga-api.js';
+import poseImages from '../../assets/images.js';
 const cloudSequenceService = require('../../utils/cloud-sequence-service.js');
 const sequenceService = require('../../utils/sequence-service.js');
 const getText = v => (typeof v === 'object' ? (v.zh || v.en || '') : v);
@@ -17,7 +18,8 @@ Page({
     showScoreModal: false,
     poseScore: null,
     scoreSkeletonImageUrl: null,
-    defaultPoseImage: DEFAULT_POSE_IMAGE
+    defaultPoseImage: DEFAULT_POSE_IMAGE,
+    poseImages
   },
 
 

--- a/smartyoga-miniprogram/pages/sequence/index.wxml
+++ b/smartyoga-miniprogram/pages/sequence/index.wxml
@@ -22,11 +22,17 @@
     </view>
 
     <view class="poseContainer">
-      <image 
-        class="poseImg" 
-        src="{{currentSequence.poses[currentPoseIndex].image_url}}" 
+      <image
+        class="poseImg"
+        src="{{currentSequence.poses[currentPoseIndex].image_url}}"
         mode="aspectFit"
         binderror="onImageError"
+      />
+      <image 
+        class="pose-photo" 
+        src="{{poseImages[currentSequence.poses[currentPoseIndex].key]}}" 
+        mode="aspectFit" 
+        style="width: 90%; max-width: 320px; margin: 12px auto; display: block;" 
       />
       <text class="poseName">{{currentSequence.poses[currentPoseIndex].displayName || currentSequence.poses[currentPoseIndex].name.zh}}</text>
       <text class="poseInstructions">{{currentSequence.poses[currentPoseIndex].instructions.zh}}</text>


### PR DESCRIPTION
## Summary
- export `poseImages` mapping from `assets/images.js`
- load `poseImages` in sequence page data
- display standard pose photo on sequence step view

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684605e0bca88329be20506facece986