### PR TITLE
Switch to cos pose images

### DIFF
--- a/smartyoga-miniprogram/pages/sequence/index.js
+++ b/smartyoga-miniprogram/pages/sequence/index.js
@@ -191,14 +191,7 @@ Page({
     console.warn('[IMAGE_ERROR] Failed to load image:', e.detail.errMsg, 'Type:', imageType, 'Index:', imageIndex);
     
     // Update the specific image that failed based on type
-    if (imageType === 'pose') {
-      // Update current pose image
-      if (this.data.currentSequence && this.data.currentSequence.poses[this.data.currentPoseIndex]) {
-        this.setData({
-          [`currentSequence.poses[${this.data.currentPoseIndex}].image_url`]: DEFAULT_POSE_IMAGE
-        });
-      }
-    } else if (imageType === 'skeleton' && imageIndex !== undefined) {
+    if (imageType === 'skeleton' && imageIndex !== undefined) {
       // Update skeleton image in topThreeFrames
       const frameIndex = parseInt(imageIndex);
       if (!isNaN(frameIndex) && this.data.topThreeFrames[frameIndex]) {

--- a/smartyoga-miniprogram/pages/sequence/index.wxml
+++ b/smartyoga-miniprogram/pages/sequence/index.wxml
@@ -23,16 +23,10 @@
 
     <view class="poseContainer">
       <image
-        class="poseImg"
-        src="{{currentSequence.poses[currentPoseIndex].image_url}}"
+        class="pose-photo"
+        src="{{poseImages[currentSequence.poses[currentPoseIndex].key]}}"
         mode="aspectFit"
-        binderror="onImageError"
-      />
-      <image 
-        class="pose-photo" 
-        src="{{poseImages[currentSequence.poses[currentPoseIndex].key]}}" 
-        mode="aspectFit" 
-        style="width: 90%; max-width: 320px; margin: 12px auto; display: block;" 
+        style="width: 90%; max-width: 320px; margin: 12px auto; display: block;"
       />
       <text class="poseName">{{currentSequence.poses[currentPoseIndex].displayName || currentSequence.poses[currentPoseIndex].name.zh}}</text>
       <text class="poseInstructions">{{currentSequence.poses[currentPoseIndex].instructions.zh}}</text>


### PR DESCRIPTION
## Summary
- show pose photos via `poseImages` URL mapping
- drop deprecated `image_url` usage on training page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68460c8d2a50832984b2d6502d81f499