### PR TITLE
Add keep screen on toggle for sequence page

### DIFF
--- a/smartyoga-miniprogram/pages/sequence/index.js
+++ b/smartyoga-miniprogram/pages/sequence/index.js
@@ -226,7 +226,11 @@ Page({
   },
 
   // Lifecycle hooks
+  onShow: function () {
+    wx.setKeepScreenOn({ keepScreenOn: true });
+  },
   onHide: function () {
+    wx.setKeepScreenOn({ keepScreenOn: false });
     this.stopTimer();
   },
 


### PR DESCRIPTION
## Summary
- ensure the device screen stays on while practicing a sequence
- disable keep-screen-on when leaving the page

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_684867fb3e30832996f31c764818da3a