### PR TITLE
Add welcome video overlay to index page

### DIFF
--- a/smartyoga-miniprogram/pages/index/index.js
+++ b/smartyoga-miniprogram/pages/index/index.js
@@ -1,7 +1,20 @@
 import { DETECT_POSE_URL } from '../../utils/yoga-api.js';
 
 Page({
-  data: {},
+  data: {
+    showWelcomeVideo: false,
+    welcomeVideoUrl: ''
+  },
+
+  onLoad() {
+    const hasWatched = wx.getStorageSync('hasWatchedWelcomeVideo');
+    if (!hasWatched) {
+      this.setData({
+        showWelcomeVideo: true,
+        welcomeVideoUrl: 'https://yogasmart-static-1351554677.cos.ap-shanghai.myqcloud.com/assets/welcome.mp4'
+      });
+    }
+  },
 
   handleSequencePress(event) {
     const level = event.currentTarget.dataset.level;
@@ -20,5 +33,18 @@ Page({
     wx.navigateTo({
       url: '/pages/photo-detect/photo-detect'
     });
+  },
+
+  onWelcomeVideoEnd() {
+    this.hideWelcomeVideo();
+  },
+
+  skipWelcomeVideo() {
+    this.hideWelcomeVideo();
+  },
+
+  hideWelcomeVideo() {
+    this.setData({ showWelcomeVideo: false });
+    wx.setStorageSync('hasWatchedWelcomeVideo', true);
   }
 });

--- a/smartyoga-miniprogram/pages/index/index.wxml
+++ b/smartyoga-miniprogram/pages/index/index.wxml
@@ -1,3 +1,16 @@
+<view wx:if="{{showWelcomeVideo}}" class="welcome-video-overlay">
+  <video
+    src="{{welcomeVideoUrl}}"
+    controls="{{false}}"
+    autoplay
+    show-center-play-btn="{{false}}"
+    enable-progress-gesture="{{false}}"
+    loop="{{false}}"
+    style="width: 100vw; height: 100vh;"
+    bindended="onWelcomeVideoEnd"
+  ></video>
+  <button class="skip-btn" bindtap="skipWelcomeVideo">跳过</button>
+</view>
 <view class="container">
   <view class="content">
     <view class="header">


### PR DESCRIPTION
## Summary
- show welcome video when first visiting the index page
- allow skipping the welcome video

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68486f81020c8329b9fa4475c96cc1ae