### PR TITLE
Unify dataset location for training

### DIFF
--- a/generate_image_list.py
+++ b/generate_image_list.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+"""
+Scan dataset/train/ and output data_lists/all_images.csv
+Columns: file,label,score  (score 固定 1)
+file 字段仅保存文件名 (不含路径)，与 train_model.py 的映射保持一致
+"""
+import os, csv, pathlib
+DATASET_DIR = "dataset/train"
+OUT_DIR = "data_lists"
+os.makedirs(OUT_DIR, exist_ok=True)
+CSV_PATH = f"{OUT_DIR}/all_images.csv"
+
+rows = []
+for pose in sorted(os.listdir(DATASET_DIR)):
+    pose_dir = pathlib.Path(DATASET_DIR, pose)
+    if not pose_dir.is_dir():
+        continue
+    for img in pose_dir.rglob("*"):
+        if img.suffix.lower() in (".jpg", ".jpeg", ".png"):
+            rows.append({
+                "file": img.name,
+                "label": pose,
+                "score": 1,
+            })
+
+with open(CSV_PATH, "w", newline="", encoding="utf-8") as f:
+    writer = csv.DictWriter(f, fieldnames=["file", "label", "score"])
+    writer.writeheader()
+    writer.writerows(rows)
+
+print(f"✅ CSV 生成完毕，共 {len(rows)} 条 -> {CSV_PATH}")
+


### PR DESCRIPTION
## Summary
- centralize dataset to `dataset/train`
- rebuild `load_training_data` to scan unified dataset
- auto-generate `data_lists/all_images.csv` when missing
- point cleanup to new `cos_tools/clear_dataset_images.py`
- add helper script `generate_image_list.py`

## Testing
- `python -m flake8 backend/train_model.py generate_image_list.py` *(fails: E501 and other style errors)*
- `pylint backend/train_model.py generate_image_list.py` *(score 4.77/10)*

------
https://chatgpt.com/codex/tasks/task_e_684df46eb1448329bf9ea7193edd7fe9