### PR TITLE
Fix Keras 3 model save call

### DIFF
--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -474,7 +474,7 @@ def save_model(model: keras.Model, model_path: str = "models/yoga_pose_score_reg
     
     # Also save in SavedModel format for better compatibility
     saved_model_path = model_path.replace('.h5', '_saved_model')
-    model.save(saved_model_path, save_format='tf')
+    model.save(saved_model_path)
     logger.info(f"Model also saved in SavedModel format to: {saved_model_path}")
 
 


### PR DESCRIPTION
## Summary
- remove deprecated `save_format` arg from Keras `model.save` call

## Testing
- `python -m py_compile backend/train_model.py`


------
https://chatgpt.com/codex/tasks/task_e_684dfecf50b08329aef1a099b72f3606