### PR TITLE
Fix Keras save path extension

### DIFF
--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -472,10 +472,17 @@ def save_model(model: keras.Model, model_path: str = "models/yoga_pose_score_reg
     model.save(model_path)
     logger.info(f"Model saved to: {model_path}")
     
-    # Also save in SavedModel format for better compatibility
-    saved_model_path = model_path.replace('.h5', '_saved_model')
+    # Also save a copy with clear extension for Keras format
+    saved_model_path = model_path.replace('.h5', '_saved_model.keras')
     model.save(saved_model_path)
-    logger.info(f"Model also saved in SavedModel format to: {saved_model_path}")
+    logger.info(
+        f"Model also saved in Keras format to: {saved_model_path}")
+
+    # Export TensorFlow SavedModel directory
+    export_dir = model_path.replace('.h5', '_saved_model')
+    model.export(export_dir)
+    logger.info(
+        f"TensorFlow SavedModel exported to: {export_dir}")
 
 
 def clear_training_data():


### PR DESCRIPTION
## Summary
- ensure `train_model.save_model` writes Keras format with explicit `.keras` extension
- add `model.export()` call for SavedModel directory

## Testing
- `python3 -m py_compile backend/train_model.py`
- `python3 backend/test_movenet.py backend/input.jpeg` *(fails: Could not open movenet model)*

------
https://chatgpt.com/codex/tasks/task_e_684e0196758483298cf1d75f47544b8d