### PR TITLE
Disable GPU for TensorFlow in training script

### DIFF
--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -14,6 +14,9 @@ Usage:
 """
 
 import os
+os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+print("使用 CPU 进行评分训练")
+
 import sys
 import subprocess
 import logging


### PR DESCRIPTION
## Summary
- disable GPU use by setting `CUDA_VISIBLE_DEVICES=-1`
- log CPU usage for training

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68573a83f4a0832985d0a2fe96a92a54