### PR TITLE
Shuffle images before limiting in data loading

### DIFF
--- a/backend/train_model.py
+++ b/backend/train_model.py
@@ -32,6 +32,7 @@ from pathlib import Path
 from typing import Tuple, List, Optional
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from functools import partial
+import random
 
 import numpy as np
 import pandas as pd
@@ -177,9 +178,11 @@ def load_training_data(workers: int = 4, max_images: int = None) -> Tuple[np.nda
             continue
         for img_path in pose_dir.rglob("*"):
             if img_path.suffix.lower() in (".jpg", ".jpeg", ".png"):
-                if max_images is not None and len(image_paths) >= max_images:
-                    break
                 image_paths.append(img_path)
+
+    if max_images is not None:
+        random.shuffle(image_paths)
+        image_paths = image_paths[:max_images]
 
     logger.info(f"Found {len(image_paths)} images in {DATASET_DIR}")
     logger.info(f"Loading images using {workers} workers...")


### PR DESCRIPTION
## Summary
- import `random` module
- shuffle collected image paths before truncating with `max_images`

## Testing
- `python -m py_compile backend/train_model.py`

------
https://chatgpt.com/codex/tasks/task_e_685752149fcc8329b55cb225c6662cbe