### PR TITLE
Add hot reload for models

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -22,6 +22,7 @@ from PIL import Image, UnidentifiedImageError # Added for image validation
 
 from pose_detector import (
     detect_pose,
+    reload_models,
     PoseDetectionError,
     NoKeypointError,
     InvalidPoseError,
@@ -638,6 +639,11 @@ def list_supported_poses_route():
     except Exception as e:
         logger.error(f"获取支持的姿势列表失败: {e}\n{traceback.format_exc()}")
         return jsonify(ResponseBuilder.error("SUPPORTED_POSES_FETCH_ERROR", "获取支持的姿势列表时发生内部错误。")), 500
+
+
+@app.route("/api/reload_model", methods=["POST"])
+def api_reload_model():
+    return reload_models()
 
 
 # ======================== 启动函数 ========================

--- a/backend/train_trigger.py
+++ b/backend/train_trigger.py
@@ -85,6 +85,13 @@ with open(log_path,"a",encoding="utf-8") as fp:
                 if ok:
                     log("✅ 评分模型训练成功", fp)
                     sync_latest("models/score", "score", "latest_model.h5", fp)
+                    import requests, traceback
+                    try:
+                        requests.post("http://127.0.0.1:5000/api/reload_model", timeout=3)
+                        print("🔔 已通知后端热更新模型")
+                    except Exception as e:
+                        traceback.print_exc()
+                        print("⚠️ 通知后端热更新失败，可等待下次 Gunicorn 重启")
                     break
                 retry += 1
                 log(f"❌ 评分模型第 {retry} 次失败", fp)
@@ -104,6 +111,13 @@ with open(log_path,"a",encoding="utf-8") as fp:
         if safe_run(cmd, fp):
             log("✅ 分类模型训练成功", fp)
             sync_latest("models/classify", "classify", "latest_model.h5", fp)
+            import requests, traceback
+            try:
+                requests.post("http://127.0.0.1:5000/api/reload_model", timeout=3)
+                print("🔔 已通知后端热更新模型")
+            except Exception as e:
+                traceback.print_exc()
+                print("⚠️ 通知后端热更新失败，可等待下次 Gunicorn 重启")
         else:
             log("❌ 分类模型训练失败", fp)
 


### PR DESCRIPTION
## Summary
- load score/classify models lazily and add reload API
- hook reload route in Flask app
- trigger backend hot reload after training

## Testing
- `pytest -q`
- `python3 -m py_compile backend/pose_detector.py backend/app.py backend/train_trigger.py`


------
https://chatgpt.com/codex/tasks/task_e_685839262e3c8329a4f3ea4764b46131